### PR TITLE
Improvement/os information gathering (#24)

### DIFF
--- a/tests/test_vmdata.py
+++ b/tests/test_vmdata.py
@@ -62,9 +62,14 @@ def test_from_file(datafile: tuple[bool, Path], caplog: pytest.LogCaptureFixture
             pd.DataFrame(
                 {
                     "OS according to the configuration file": [
+                        "",
+                        "",
+                        "CentOS 7",
+                    ],
+                    "OS according to the VMware Tools": [
                         "Windows 10",
                         "Ubuntu 20.04",
-                        "CentOS 7",
+                        "",
                     ],
                     "ent-env": ["Prod", "Dev", "Prod"],
                     "Memory": [8, 16, 32],

--- a/vminfo_parser/const.py
+++ b/vminfo_parser/const.py
@@ -4,7 +4,8 @@ COLUMN_HEADERS = MappingProxyType(
     {
         "VERSION_1": MappingProxyType(
             {
-                "operatingSystem": "VM OS",
+                "operatingSystemFromVMTools": "VM OS",
+                "operatingSystemFromVMConfig": "VM OS",
                 "environment": "Environment",
                 "vmMemory": "VM MEM (GB)",
                 "vmDisk": "VM Provisioned (GB)",
@@ -13,7 +14,8 @@ COLUMN_HEADERS = MappingProxyType(
         ),
         "VERSION_2": MappingProxyType(
             {
-                "operatingSystem": "OS according to the configuration file",
+                "operatingSystemFromVMConfig": "OS according to the configuration file",
+                "operatingSystemFromVMTools": "OS according to the VMware Tools",
                 "environment": "ent-env",
                 "vmMemory": "Memory",
                 "vmDisk": "Total disk capacity MiB",

--- a/vminfo_parser/vminfo_parser.py
+++ b/vminfo_parser/vminfo_parser.py
@@ -84,7 +84,7 @@ class VMData:
 
         if missing_headers:
             LOGGER.debug(f"Using VERSION_{best_match} as the closest match.")
-            LOGGER.critical(f"The following headers are missing:")
+            LOGGER.critical("The following headers are missing:")
             for header in missing_headers:
                 LOGGER.critical(f"- {header}")
             exit()

--- a/vminfo_parser/vminfo_parser.py
+++ b/vminfo_parser/vminfo_parser.py
@@ -58,29 +58,54 @@ class VMData:
         return cls(df)
 
     def set_column_headings(self: t.Self) -> None:
+        """
+        Sets the column headings based on the versions defined in const.COLUMN_HEADERS.
+        Raises:
+            ValueError: If no matching header set is found.
+        """
+        best_match = None
+        max_matches = 0
+
         for version, headers in const.COLUMN_HEADERS.items():
-            if all(col in self.df.columns for col in headers.values()):
-                self.column_headers = headers.copy()
-                self.column_headers["unitType"] = "GB" if version == "VERSION_1" else "MB"
-                break
-        else:
-            LOGGER.error(
-                "Missing column headers from either %s",
-                " or ".join(
-                    [str([header for header in version.values()]) for version in const.COLUMN_HEADERS.values()]
-                ),
-            )
-            raise ValueError("Headers don't match either of the versions expected")
+            matches = 0
+            for header in headers.values():
+                if header in self.df.columns:
+                    matches += 1
+            if matches > max_matches:
+                max_matches = matches
+                best_match = version
+
+        if best_match is None:
+            raise ValueError("No matching header set found")
+
+        self.column_headers = const.COLUMN_HEADERS[best_match].copy()
+        missing_headers = [header for header in self.column_headers.values() if header not in self.df.columns]
+        self.column_headers["unitType"] = "GB" if best_match == "VERSION_1" else "MB"
+
+        if missing_headers:
+            LOGGER.debug(f"Using VERSION_{best_match} as the closest match.")
+            LOGGER.critical(f"The following headers are missing:")
+            for header in missing_headers:
+                LOGGER.critical(f"- {header}")
+            exit()
 
     def add_extra_columns(self: t.Self) -> None:
-        os_column = self.column_headers["operatingSystem"]
+        primary_os_column = self.column_headers.get("operatingSystemFromVMTools")
+        secondary_os_column = self.column_headers.get("operatingSystemFromVMConfig")
+
+        combined_os_column = "combined_operating_system"
+        self.df[combined_os_column] = self.df[secondary_os_column].where(
+            self.df[primary_os_column].isnull(), self.df[primary_os_column]
+        )
 
         if not all(col in self.df.columns for col in const.EXTRA_COLUMNS_DEST):
-            self.df[const.EXTRA_COLUMNS_DEST] = self.df[os_column].str.extract(const.EXTRA_COLUMNS_NON_WINDOWS_REGEX)
-            self.df[const.EXTRA_WINDOWS_SERVER_COLUMNS] = self.df[os_column].str.extract(
+            self.df[const.EXTRA_COLUMNS_DEST] = self.df[combined_os_column].str.extract(
+                const.EXTRA_COLUMNS_NON_WINDOWS_REGEX
+            )
+            self.df[const.EXTRA_WINDOWS_SERVER_COLUMNS] = self.df[combined_os_column].str.extract(
                 const.EXTRA_COLUMNS_WINDOWS_SERVER_REGEX
             )
-            self.df[const.EXTRA_WINDOWS_DESKTOP_COLUMNS] = self.df[os_column].str.extract(
+            self.df[const.EXTRA_WINDOWS_DESKTOP_COLUMNS] = self.df[combined_os_column].str.extract(
                 const.EXTRA_COLUMNS_WINDOWS_DESKTOP_REGEX, flags=re.IGNORECASE
             )
 
@@ -91,7 +116,10 @@ class VMData:
                 self.df[column] = self.df[const.EXTRA_WINDOWS_DESKTOP_COLUMNS[idx]].where(
                     self.df[column].isnull(), self.df[column]
                 )
-
+            self.df[const.EXTRA_COLUMNS_DEST[0]] = self.df[secondary_os_column].where(
+                self.df[primary_os_column].isnull(),
+                self.df[const.EXTRA_COLUMNS_DEST[0]],
+            )
             self.df.drop(
                 const.EXTRA_WINDOWS_SERVER_COLUMNS + const.EXTRA_WINDOWS_DESKTOP_COLUMNS,
                 axis=1,


### PR DESCRIPTION

This PR adds the ability for the program to first look for a VMWare tools column and if that row is empty, it will then grab the value from the VM Config column.

In addition, in order to support better header handling, this PR also changes the set_column_headings() function so that it now identifies which version of headers is likely the best match (using LOGGER.debug) and then determining which headers from the closest version are missing and provides this via text output
