### PR TITLE
bugfix: convert output to strings

### DIFF
--- a/tests/test_clioutput.py
+++ b/tests/test_clioutput.py
@@ -1,0 +1,25 @@
+import typing as t
+
+import pytest
+
+from vminfo_parser.vminfo_parser import CLIOutput
+
+
+@pytest.fixture
+def cli_output() -> t.Generator[CLIOutput, None, None]:
+    co = CLIOutput()
+    co.output.truncate()
+    yield co
+    co.output.close()
+
+
+@pytest.mark.parametrize("arg", ["string", "string\n", None, 0, 0.1, object()], ids=type)
+def test_write(cli_output: CLIOutput, arg: t.Any) -> None:
+    cli_output.write(arg)
+    assert cli_output.output.getvalue() == str(arg)
+
+
+@pytest.mark.parametrize("arg", ["string", "string\n", None, 0, 0.1, object()], ids=type)
+def test_writeline(cli_output: CLIOutput, arg: t.Any) -> None:
+    cli_output.writeline(arg)
+    assert cli_output.output.getvalue() == f"{arg}" if str(arg).endswith("\n") else f"{arg}\n"

--- a/vminfo_parser/vminfo_parser.py
+++ b/vminfo_parser/vminfo_parser.py
@@ -202,22 +202,26 @@ class CLIOutput:
         file.write(output.getvalue())
         output.close()
 
-    def writeline(self: t.Self, line: str = "") -> None:
+    def writeline(self: t.Self, line: t.Any = "") -> None:
         """write string to output buffer.  Adds newline if line does not end with one.
 
         Args:
             line (str, optional): string to write to output buffer. Defaults to "".
         """
+        if not isinstance(line, str):
+            line: str = str(line)
         if not line.endswith("\n"):
             line = line + "\n"
         self.write(line)
 
-    def write(self: t.Self, line: str) -> None:
+    def write(self: t.Self, line: t.Any) -> None:
         """Write string to output buffer.
 
         Args:
             line (str): string to write to output buffer
         """
+        if not isinstance(line, str):
+            line: str = str(line)
         self.output.write(line)
 
     def close(self: t.Self) -> None:


### PR DESCRIPTION
Convert output to strings before writing to output buffer,

Add tests to insure string, None, int, float, and object are all handled properly.

fixes #29