### PR TITLE
fix(analyzer): normalized the data in the disk column to GB for disk space calculations

### DIFF
--- a/vminfo_parser/vminfo_parser.py
+++ b/vminfo_parser/vminfo_parser.py
@@ -134,7 +134,6 @@ class Analyzer:
         # This copy has a paired down version of the information and then environments have been changed to prod/non-prod
         diskHeading = self.column_headers["vmDisk"]
         envHeading = self.column_headers["environment"]
-        unit = self.column_headers["unitType"]
 
         disk_space_ranges = self.calculate_disk_space_ranges(
             dataFrame=dataFrame,

--- a/vminfo_parser/vminfo_parser.py
+++ b/vminfo_parser/vminfo_parser.py
@@ -62,10 +62,9 @@ class Analyzer:
                 dataFrame.at[index, frameHeading] = row[frameHeading].replace(",", "")
 
         dataFrame[frameHeading] = pd.to_numeric(dataFrame[frameHeading], errors="coerce")
-        unit = self.column_headers["unitType"]
 
         # Normalize the Disk Column to GiB before applying further analysis
-        if unit == "MB":
+        if self.column_headers["unitType"] == "MB":
             dataFrame[frameHeading] = dataFrame[frameHeading] / 1024
         min_disk_space = round(int(dataFrame[frameHeading].min()))
         max_disk_space = round(int(dataFrame[frameHeading].max()))


### PR DESCRIPTION
fix: disk space units normalization

A bug was discovered in some cases where data sets reporting their disk space in MiB were not being categorized properly when doing a break down by terabyte.

The units in the dataframe are now normalized to GiB (from MiB) before any analysis or sorting is done

fixes: https://github.com/rhtools/vminfo-parser/issues/49