### PR TITLE
feat: Adding the ability to granularly display disk space ranges 

### DIFF
--- a/tests/test_clioutput.py
+++ b/tests/test_clioutput.py
@@ -1,5 +1,6 @@
 import typing as t
 
+import pandas as pd
 import pytest
 
 from vminfo_parser.clioutput import CLIOutput
@@ -23,3 +24,200 @@ def test_write(cli_output: CLIOutput, arg: t.Any) -> None:
 def test_writeline(cli_output: CLIOutput, arg: t.Any) -> None:
     cli_output.writeline(arg)
     assert cli_output.output.getvalue() == f"{arg}" if str(arg).endswith("\n") else f"{arg}\n"
+
+
+@pytest.mark.parametrize(
+    "df, formatted_rows, justification, col_widths, index_column_name, expected",
+    [
+        (
+            pd.DataFrame({"Disk Space Range": ["0 - 200 GB", "1 - 2 TB"], "non-prod": [3, 4], "prod": [5, 6]}),
+            [],
+            15,
+            {"Disk Space Range": 22, "non-prod": 10, "prod": 10},
+            "Disk Space Range",
+            "0 - 200 GB                             3          5         \n"
+            "1 - 2 TB                               4          6         ",
+        ),
+        (
+            pd.DataFrame(
+                {"OS Version": ["7", "9"], "Disk Space Range": ["10 - 20 TB", "801 GB - 1 TB"], "Count": [15, 26]}
+            ),
+            [],
+            15,
+            {"OS Version": 0, "Disk Space Range": 19, "Count": 19},
+            "OS Version",
+            "7                10 - 20 TB          15                 \n"
+            "9                801 GB - 1 TB       26                 ",
+        ),
+    ],
+)
+def test_format_rows(
+    cli_output: CLIOutput,
+    df: pd.DataFrame,
+    formatted_rows: list,
+    justification: int,
+    col_widths: dict,
+    index_column_name: str,
+    expected: str,
+):
+    # Depending on what is being formatted, the index of the dataframe is different
+    df = df.set_index(f"{index_column_name}")
+    result = cli_output.format_rows(df, formatted_rows, justification, col_widths)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "df, index_column_padding, remaining_column_padding, current_index_column_name, new_index_column_name, expected",
+    [
+        (
+            pd.DataFrame(
+                pd.DataFrame({"Disk Space Range": ["0 - 200 GB", "1 - 2 TB"], "non-prod": [3, 4], "prod": [5, 6]})
+            ),
+            22,
+            10,
+            "Disk Space Range",
+            "Environment",
+            {"Environment": 22, "non-prod": 10, "prod": 10},
+        ),
+        (
+            pd.DataFrame(
+                {"OS Version": ["7", "9"], "Disk Space Range": ["10 - 20 TB", "801 GB - 1 TB"], "Count": [15, 26]}
+            ),
+            0,
+            19,
+            "OS Version",
+            "OS Version Number",
+            {"OS Version Number": 0, "Disk Space Range": 19, "Count": 19},
+        ),
+        (
+            pd.DataFrame({"Disk Space Range": ["20 - 50 TB", "801 GB - 1 TB"], "Count": [335, 2006]}),
+            17,
+            17,
+            "Disk Space Range",
+            None,
+            {"Count": 17},
+        ),
+    ],
+)
+def test_set_column_width(
+    cli_output: CLIOutput,
+    df: pd.DataFrame,
+    index_column_padding: int,
+    remaining_column_padding: int,
+    current_index_column_name: str,
+    new_index_column_name: str,
+    expected: dict,
+):
+    # There is some manipulation of the df that is required in order to mock real data
+    # the index needs to be set, but the index column heading is sometimes changed for clarity
+    df = df.set_index(f"{current_index_column_name}")
+    result = cli_output.set_column_width(df, index_column_padding, remaining_column_padding, new_index_column_name)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "col_widths, formatted_df_str, os_filter, display_header, index_heading_justification, "
+    "other_headings_justification, expected_output",
+    [
+        (
+            {"Environment": 22, "non-prod": 10, "prod": 10},
+            "0 - 200 GB                             31         247       "
+            "201 - 400 GB                           26         34        ",
+            None,
+            True,
+            39,
+            11,
+            "Environment                            non-prod   prod       \n"
+            "0 - 200 GB                             31         247       "
+            "201 - 400 GB                           26         34        \n\n",
+        ),
+        (
+            {"Count": 17},
+            "Disk Space Range    Count            \n"
+            "0 - 200 GB          278              \n"
+            "201 - 400 GB        60               ",
+            None,
+            True,
+            39,
+            11,
+            "\nDisk Space Range    Count            \n"
+            "0 - 200 GB          278              \n"
+            "201 - 400 GB        60               \n\n",
+        ),
+        (
+            {"OS Version Number": 0, "Disk Space Range": 19, "Count": 19},
+            "7                        0 - 200 GB          50                 \n"
+            "8                        401 - 600 GB        52                 \n"
+            "9                        20 - 36.3 TB        2                  ",
+            "Red Hat Enterprise Linux",
+            True,
+            25,
+            20,
+            "Red Hat Enterprise Linux\n"
+            "---------------------------------\n"
+            "OS Version Number        Disk Space Range    Count               \n"
+            "7                        0 - 200 GB          50                 \n"
+            "8                        401 - 600 GB        52                 \n"
+            "9                        20 - 36.3 TB        2                  \n\n",
+        ),
+    ],
+)
+def test_print_formatted_disk_space(
+    cli_output: CLIOutput,
+    col_widths: dict,
+    formatted_df_str: str,
+    os_filter: str,
+    display_header: bool,
+    index_heading_justification: int,
+    other_headings_justification: int,
+    expected_output: str,
+):
+    cli_output.print_formatted_disk_space(
+        col_widths,
+        formatted_df_str,
+        os_filter=os_filter,
+        display_header=display_header,
+        index_heading_justification=index_heading_justification,
+        other_headings_justification=other_headings_justification,
+    )
+    result = cli_output.output.getvalue()
+    assert result == expected_output
+
+
+@pytest.mark.parametrize(
+    "resource_list, df, expected",
+    [
+        (
+            ["Memory", "CPU", "Disk", "VM"],
+            pd.DataFrame(
+                {
+                    "Site Name": ["Site1", "Site2"],
+                    "Site_RAM_Usage": [533, 764],
+                    "Site_Disk_Usage": [779, 247],
+                    "Site_CPU_Usage": [2594, 970],
+                    "Site_VM_Count": [428, 177],
+                }
+            ),
+            "Site Wide Memory Usage\n"
+            "-------------------\n"
+            "Site1		533 GB\n"
+            "Site2		764 GB\n\n"
+            "Site Wide CPU Usage\n"
+            "-------------------\n"
+            "Site1		2594 Cores\n"
+            "Site2		970 Cores\n\n"
+            "Site Wide Disk Usage\n"
+            "-------------------\n"
+            "Site1		779 TB\n"
+            "Site2		247 TB\n\n"
+            "Site Wide VM Usage\n"
+            "-------------------\n"
+            "Site1		428 VMs\n"
+            "Site2		177 VMs\n\n",
+        ),
+    ],
+)
+def test_print_site_usage(cli_output: CLIOutput, resource_list: list, df: pd.DataFrame, expected):
+    cli_output.print_site_usage(resource_list, df)
+    result = cli_output.output.getvalue()
+    assert result == expected

--- a/vminfo_parser/clioutput.py
+++ b/vminfo_parser/clioutput.py
@@ -86,30 +86,30 @@ class CLIOutput:
             if not line.startswith("Name:") and not line.startswith("dtype"):
                 self.writeline(line.strip())
 
-    def print_formatted_disk_space(
+    def format_rows(
         self: t.Self,
-        sorted_range_counts_by_environment: pd.DataFrame,
-        environment_filter: str,
-        env_keywords: list[str],
-        os_filter: t.Optional[str] = None,
-    ) -> None:
-        col_widths = (
-            {
-                "Environment": 22,
-                **{env: 10 for env in sorted_range_counts_by_environment.columns},
-            }
-            if env_keywords and environment_filter != "all"
-            else {**{env: 17 for env in sorted_range_counts_by_environment.columns}}
-        )
-        formatted_rows = []
+        dataFrame: pd.DataFrame,
+        formatted_rows: list,
+        justification: int,
+        col_widths: dict,
+    ) -> str:
+        """
+        Format the rows of a DataFrame into a string representation with specified widths.
 
-        if environment_filter == "all":
-            formatted_rows.append("Disk Space Range".ljust(20) + "Count".ljust(col_widths["Count"]))
-            justification = 19
-        else:
-            justification = 15
+        This function iterates over each row in the provided DataFrame, formats the row values according to
+        the specified column widths, and appends the formatted rows to the provided list. The resulting string
+        representation of the formatted rows is returned.
 
-        for index, row in sorted_range_counts_by_environment.iterrows():
+        Args:
+            dataFrame (pd.DataFrame): The DataFrame containing the data to format.
+            formatted_rows (list): A list to which the formatted row strings will be appended.
+            justification (int): The width for left-justifying the index values.
+            col_widths (dict): A dictionary mapping column names to their respective widths.
+
+        Returns:
+            str: A string representation of the formatted rows, joined by newline characters.
+        """
+        for index, row in dataFrame.iterrows():
             formatted_row = [str(index).ljust(justification)]
             for col_name, width in col_widths.items():
                 value = str(row[col_name]) if col_name in row.index else ""
@@ -118,25 +118,79 @@ class CLIOutput:
 
         formatted_df_str = "\n".join(formatted_rows)
 
+        return formatted_df_str
+
+    def set_column_width(
+        self: t.Self,
+        dataFame: pd.DataFrame,
+        index_column_padding: int,
+        remaining_column_padding: int,
+        index_column_name: str = None,
+    ) -> dict:
+        """
+        Set the widths for the columns in a DataFrame based on specified parameters.
+        This function returns a dictionary mapping column names to their respective widths for formatting purposes.
+
+        Args:
+            dataFame (pd.DataFrame): The DataFrame for which column widths are to be set.
+            index_column_width (int): The width to be assigned to the index column.
+            remaining_column_widths (int): The width to be assigned to the remaining columns.
+            index_column_name (str, optional): The name of the index column. If provided, it will be assigned the
+                specified width. Defaults to None.
+
+        Returns:
+            dict: A dictionary mapping each column name to its corresponding width.
+
+        Examples:
+            >>> set_column_width(dataFame=my_dataframe, index_column_width=20, remaining_column_widths=10,
+                index_column_name="Environment")
+            {'Environment': 20, 'Column1': max(10, len('Column1')), 'Column2': max(10, len('Column2'))}
+        """
+        if index_column_name:
+            col_widths = {
+                index_column_name: index_column_padding,
+                **{env: max(remaining_column_padding, len(env)) for env in dataFame.columns},
+            }
+        else:
+            col_widths = {env: max(index_column_padding, len(env)) for env in dataFame.columns}
+
+        return col_widths
+
+    def print_formatted_disk_space(
+        self: t.Self,
+        col_widths: dict,
+        formatted_df_str: str,
+        os_filter: t.Optional[str] = None,
+        display_header: bool = True,
+        index_heading_justification: int = 39,
+        other_headings_justification: int = 11,
+    ) -> None:
+        """
+        Print the formatted disk space information to the output.
+        This function displays a header and the formatted data, optionally filtered by the operating system.
+
+        Args:
+            col_widths (dict): A dictionary containing the widths for each column in the output.
+            formatted_df_str (str): A string representation of the formatted disk space data.
+            os_filter (Optional[str]): An optional filter to display specific operating system information.
+
+        Returns:
+            None
+        """
         temp_heading = ""
         if os_filter:
             self.writeline(os_filter)
             self.writeline("---------------------------------")
-
-        for headings in list(col_widths.keys()):
-            if temp_heading:
-                temp_heading += headings.ljust(11)
-            else:
-                temp_heading += headings.ljust(39)
+        if display_header:
+            if len(col_widths) > 1:
+                for headings in list(col_widths.keys()):
+                    if temp_heading:
+                        temp_heading += headings.ljust(other_headings_justification)
+                    else:
+                        temp_heading += headings.ljust(index_heading_justification)
         self.writeline(temp_heading)
         self.writeline(formatted_df_str)
         self.writeline()
-
-    def print_disk_space_ranges(self: t.Self, range_counts: dict[tuple[int, int], int]) -> None:
-        self.writeline("Disk Space Range (GB)\t\tCount")
-        for disk_range, count in range_counts.items():
-            disk_range_str = f"{disk_range[0]}-{disk_range[1]}"
-            self.writeline(f"{disk_range_str.ljust(32)} {count}")
 
     def print_site_usage(self: t.Self, resource_list: list, dataFrame: pd.DataFrame) -> None:
         """
@@ -145,7 +199,8 @@ class CLIOutput:
 
         Args:
             resource_list (list): The type of resource to summarize. Options include "Memory", "CPU", "Disk", or "VM".
-            dataFrame (pd.DataFrame): A DataFrame containing the relevant data for the site, including resource usage metrics.
+            dataFrame (pd.DataFrame): A DataFrame containing the relevant data for the site, including
+                                      resource usage metrics.
 
         Returns:
             None: This function does not return a value; it prints the usage information directly to the console.

--- a/vminfo_parser/config.py
+++ b/vminfo_parser/config.py
@@ -66,6 +66,12 @@ def _get_parser() -> argparse.ArgumentParser:
         help="Show disk space by OS",
     )
     parser.add_argument(
+        "--disk-space-by-granular-os",
+        action="store_true",
+        default=False,
+        help="When getting disk space by os, this breaks those results more granularly",
+    )
+    parser.add_argument(
         "--breakdown-by-terabyte",
         action="store_true",
         default=False,

--- a/vminfo_parser/vminfo_parser.py
+++ b/vminfo_parser/vminfo_parser.py
@@ -71,6 +71,7 @@ def main(*args: t.Optional[str]) -> None:  # noqa: C901
                         os_filter=os_name,
                         environment_filter=config.sort_by_env,
                         over_under_tb=config.over_under_tb,
+                        granular_disk_space_by_os=config.disk_space_by_granular_os,
                     )
 
                 else:


### PR DESCRIPTION
feature: Adding the ability to granularly display disk space ranges 

This feature allows for the tabulation of data breaking down the disk space ranges based on the OS Name and Version
```
Red Hat Enterprise Linux
---------------------------------
Disk Space Range    Count            
7                   0 - 200 GB        43               
7                   201 - 400 GB      7                
7                   401 - 600 GB      3                
7                   601 - 800 GB      3                
7                   5 - 10 TB         3                
7                   20 - 38.5 TB      1                
```

