### PR TITLE
ci(release): initial pass at release promotion

### DIFF
--- a/.github/workflows/conventional-commit-pr.yaml
+++ b/.github/workflows/conventional-commit-pr.yaml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   validate-pr-title:
     runs-on: ubuntu-latest
+    if: ${{github.repository}} == ${{github.event.repository}}
     steps:
       - name: PR Conventional Commit Validation
         uses: ytanikin/PRConventionalCommits@1.3.0

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -38,7 +38,6 @@ jobs:
         run: |
           python -m build
       - name: Release Upload Assets
-        uses: jaywcjlove/github-action-upload-assets@main
-        with:
-          asset-path: '["dist/*"]'
-          tag: "v${{steps.release_version.outputs.version}}"
+        env:
+          TAG: "v${{steps.release_version.outputs.version}}"
+        run: gh release upload ${TAG} dist/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,76 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: false
+        description: "Version Tag to Release"
+        default: ""
+        type: string
+      prerelease:
+        required: false
+        default: false
+        type: boolean
+        description: "Mark as Prerelease"
+      draft:
+        required: false
+        default: true
+        type: boolean
+        description: "Mark as Draft"
+
+env:
+  TAG: ${{inputs.tag}}
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: set release tag
+        if: ${{env.tag}} == ''
+        run: |
+          TAG=$(git -P tag --points-at HEAD)
+          if ${TAG} != ''; then
+              echo "TAG=${TAG}" >> "$GITHUB_ENV"
+          fi
+      - name: Semantic Release
+        if: ${{env.tag}} == ''
+        id: release_version
+        uses: go-semantic-release/action@v1.21.0
+        with:
+          github-token: ${{ github.token }}
+          prerelease: ${{inputs.prerelease}}
+      - name: set tag from semantic release
+        if: ${{steps.release_version.conclusion}} == "success"
+        run: echo "TAG=${TAG}" >> "$GITHUB_ENV"
+        env:
+          TAG: "v${{steps.release_version.outputs.version}}"
+      - name: checkout tag
+        id: checkout_tag
+        if: ${{steps.release_version.conclusion}} == "skipped"
+        run: git checkout ${TAG}
+        env:
+          TAG: ${{env.TAG}}
+      - name: handle release
+        if: ${{steps.checkout_tag.conclusion}} == "success"
+        run: |
+          if "$(gh release view ${TAG})" == ""; then
+            cmd="gh release create --tag ${TAG}"
+            if "${{inputs.prerelease}}" == "true"; then
+              cmd="${cmd} --prerelease" 
+            fi
+            if "${{inputs.draft}}" == "true"; then
+              cmd="${cmd} --draft" 
+            fi
+          else:
+            if "$(gh release view ${TAG} --json isPrerelease -q '.isPrerelease')" != "${{inputs.prerelease}}": then
+              gh release edit ${TAG} --prerelease=${{inputs.prerelease}}
+            fi
+            if "$(gh release view ${TAG} --json isDraft -q '.isDraft')" != "${{inputs.draft}}"; then
+              gh release edit ${TAG} --draft=${{inputs.draft}}
+          fi
+          if "${{inputs.draft}}" == "false" && "${{inputs.prerelease}}" == "false"; then
+            gh release edit ${TAG} --latest
+          fi


### PR DESCRIPTION
For discussion.

This would create a manual option to both cut a release and to promote an existing release.  All uses of this workflow default to drafts,  but that can be overridden.  It should not duplicate a release, and it should fail if a tag is specified that doesn't exist.