### PR TITLE
feat: generate yaml

### DIFF
--- a/tests/const.py
+++ b/tests/const.py
@@ -22,7 +22,7 @@ SERVER_NAME_MATCHES = {
         "OS_Version": None,
         "Architecture": "64-bit",
     },
-    "Linux 4.18.0-477.27.2.el8_8.x86_64 AlmaLinux 8.8 (Sapphire Caracal) 8.8 AlmaLinux 8.8 (Sapphire Caracal) cpe:/o:almalinux:almalinux:8::baseos": None,
+    "Linux 4.18.0-477.27.2.el8_8.x86_64 AlmaLinux 8.8 (Sapphire Caracal) 8.8 AlmaLinux 8.8 (Sapphire Caracal) cpe:/o:almalinux:almalinux:8::baseos": None,  # noqa
     "Linux 6.1.11 Other Linux 6.x and later kernel": None,
     "Oracle Linux 4/5 (64-bit)": {"OS_Name": "Oracle Linux", "OS_Version": "4/5 ", "Architecture": "64-bit"},
     "Oracle Linux 4/5/6 (64-bit)": {"OS_Name": "Oracle Linux", "OS_Version": "4/5/6 ", "Architecture": "64-bit"},
@@ -320,7 +320,24 @@ EXPECTED_CLI_OUTPUT = {
     ),
 }
 
-
+EXPECTED_ARGPARSE_TO_YAML = {
+    "breakdown_by_terabyte": False,
+    "disk_space_by_granular_os": False,
+    "file": "testfile.yaml",
+    "generate_graphs": False,
+    "get_disk_space_ranges": False,
+    "get_os_counts": False,
+    "get_supported_os": False,
+    "get_unsupported_os": False,
+    "minimum_count": 0,
+    "os_name": None,
+    "output_os_by_version": False,
+    "over_under_tb": False,
+    "prod_env_labels": None,
+    "show_disk_space_by_os": False,
+    "sort_by_env": None,
+    "sort_by_site": False,
+}
 TEST_DATAFRAMES = [
     {
         "df": {

--- a/tests/test_clioutput.py
+++ b/tests/test_clioutput.py
@@ -59,7 +59,7 @@ def test_format_rows(
     col_widths: dict,
     index_column_name: str,
     expected: str,
-):
+) -> None:
     # Depending on what is being formatted, the index of the dataframe is different
     df = df.set_index(f"{index_column_name}")
     result = cli_output.format_rows(df, formatted_rows, justification, col_widths)
@@ -107,7 +107,7 @@ def test_set_column_width(
     current_index_column_name: str,
     new_index_column_name: str,
     expected: dict,
-):
+) -> None:
     # There is some manipulation of the df that is required in order to mock real data
     # the index needs to be set, but the index column heading is sometimes changed for clarity
     df = df.set_index(f"{current_index_column_name}")
@@ -171,7 +171,7 @@ def test_print_formatted_disk_space(
     index_heading_justification: int,
     other_headings_justification: int,
     expected_output: str,
-):
+) -> None:
     cli_output.print_formatted_disk_space(
         col_widths,
         formatted_df_str,
@@ -217,7 +217,7 @@ def test_print_formatted_disk_space(
         ),
     ],
 )
-def test_print_site_usage(cli_output: CLIOutput, resource_list: list, df: pd.DataFrame, expected):
+def test_print_site_usage(cli_output: CLIOutput, resource_list: list, df: pd.DataFrame, expected) -> None:
     cli_output.print_site_usage(resource_list, df)
     result = cli_output.output.getvalue()
     assert result == expected

--- a/vminfo_parser/config.py
+++ b/vminfo_parser/config.py
@@ -229,7 +229,7 @@ class Config:
                 continue  # Skip the help action
 
             arg_name = action.dest
-            if arg_name in ["generate_yaml", "yaml", "file"]:
+            if arg_name in ["generate_yaml", "yaml"]:
                 continue  # Skip the --generate-yaml option itself
 
             args_dict[arg_name] = action.default

--- a/vminfo_parser/config.py
+++ b/vminfo_parser/config.py
@@ -232,17 +232,7 @@ class Config:
             if arg_name in ["generate_yaml", "yaml", "file"]:
                 continue  # Skip the --generate-yaml option itself
 
-            args_dict[arg_name] = {"value": action.default, "help": action.help}
-
-            if isinstance(action, argparse._StoreAction):
-                args_dict[arg_name] = "<String>"
-            elif isinstance(action, argparse._CountAction):
-                args_dict[arg_name] = "int"
-            elif isinstance(action, argparse._StoreTrueAction):
-                args_dict[arg_name] = False
-
-            if action.choices:
-                args_dict[arg_name]["choices"] = action.choices
+            args_dict[arg_name] = action.default
 
         sorted_args_dict = dict(sorted(args_dict.items()))
 

--- a/vminfo_parser/vminfo_parser.py
+++ b/vminfo_parser/vminfo_parser.py
@@ -44,6 +44,8 @@ def main(*args: t.Optional[str]) -> None:  # noqa: C901
         )
         exit()
 
+    if config.generate_yaml:
+        config.generate_yaml_from_parser()
     if config.show_disk_space_by_os:
         if config.os_name:
             # If the user specifies an OS, use that to filter out everything else

--- a/vminfo_parser/vminfo_parser.py
+++ b/vminfo_parser/vminfo_parser.py
@@ -18,7 +18,9 @@ LOGGER = logging.getLogger(__name__)
 def main(*args: t.Optional[str]) -> None:  # noqa: C901
     config = Config()
     config = Config.from_args(*args)
-
+    if config.generate_yaml:
+        config.generate_yaml_from_parser(config)
+        exit()
     vm_data = VMData.from_file(config.file)
     vm_data.set_column_headings()
     vm_data.add_extra_columns()
@@ -44,8 +46,6 @@ def main(*args: t.Optional[str]) -> None:  # noqa: C901
         )
         exit()
 
-    if config.generate_yaml:
-        config.generate_yaml_from_parser()
     if config.show_disk_space_by_os:
         if config.os_name:
             # If the user specifies an OS, use that to filter out everything else


### PR DESCRIPTION
feat: This PR is relatively simple. It allows you to create a yaml file of all of the current argparse options (except for the `--yaml` and `--generate-yaml` which wouldn't be used in the yaml you run anyways)

This adds some tests, and subsequently adjusts some of the CLIOutput tests for flake8 compliance

End to end test will need to be added if desired. Unit test is in place