### PR TITLE
refactor(main): refactor analyzer environment filtering, os counting, and disk space counting

### DIFF
--- a/tests/const.py
+++ b/tests/const.py
@@ -1086,6 +1086,7 @@ MAIN_FUNCTION_CALLS = {
     "sort_by_site": ["vm_data", "cli_output"],
     "show_disk_space_by_os": ["config", "vm_data", "analyzer"],
     "get_disk_space_ranges": ["config", "analyzer"],
+    "get_os_counts": ["config", "analyzer", "cli_output", "visualizer"],
     "output_os_by_version": ["config", "analyzer", "cli_output", "visualizer"],
     "get_supported_os": ["config", "analyzer", "cli_output", "visualizer"],
     "get_unsupported_os": ["analyzer", "cli_output", "visualizer"],

--- a/tests/const.py
+++ b/tests/const.py
@@ -1084,8 +1084,8 @@ TEST_DATAFRAMES = [
 
 MAIN_FUNCTION_CALLS = {
     "sort_by_site": ["vm_data", "cli_output"],
-    "show_disk_space_by_os": ["config", "vm_data", "analyzer"],
-    "get_disk_space_ranges": ["config", "analyzer"],
+    "show_disk_space_by_os": ["config", "analyzer", "cli_output", "visualizer"],
+    "get_disk_space_ranges": ["config", "analyzer", "cli_output", "visualizer"],
     "get_os_counts": ["config", "analyzer", "cli_output", "visualizer"],
     "output_os_by_version": ["config", "analyzer", "cli_output", "visualizer"],
     "get_supported_os": ["config", "analyzer", "cli_output", "visualizer"],

--- a/tests/const.py
+++ b/tests/const.py
@@ -1087,7 +1087,7 @@ MAIN_FUNCTION_CALLS = {
     "show_disk_space_by_os": ["config", "analyzer", "cli_output", "visualizer"],
     "get_disk_space_ranges": ["config", "analyzer", "cli_output", "visualizer"],
     "get_os_counts": ["config", "analyzer", "cli_output", "visualizer"],
-    "output_os_by_version": ["config", "analyzer", "cli_output", "visualizer"],
+    "output_os_by_version": ["analyzer", "cli_output", "visualizer"],
     "get_supported_os": ["config", "analyzer", "cli_output", "visualizer"],
     "get_unsupported_os": ["analyzer", "cli_output", "visualizer"],
 }

--- a/tests/e2e/test_main.py
+++ b/tests/e2e/test_main.py
@@ -22,5 +22,7 @@ def test_main_with_args(cli_args: list[str], expected_output: str, capsys: pytes
     # Get the output
     output = capsys.readouterr()
 
+    with open("testout.txt", "w") as file:
+        file.write(output.out)
     # Add your assertions here
     assert expected_output in output.out.strip()

--- a/tests/e2e/test_main.py
+++ b/tests/e2e/test_main.py
@@ -22,7 +22,5 @@ def test_main_with_args(cli_args: list[str], expected_output: str, capsys: pytes
     # Get the output
     output = capsys.readouterr()
 
-    with open("testout.txt", "w") as file:
-        file.write(output.out)
     # Add your assertions here
     assert expected_output in output.out.strip()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -343,3 +343,43 @@ def test_output_os_by_version_no_graphs(
         ]
     )
     mock_visualizer.visualize_os_version_distribution.assert_not_called()
+
+
+def test_get_disk_space_ranges(
+    mock_config: MockType, mock_analyzer: MockType, mock_clioutput: MockType, mock_visualizer: MockType
+) -> None:
+    mock_analyzer.get_disk_space.return_value.empty = False
+    __main__.get_disk_space_ranges(mock_config, mock_analyzer, mock_clioutput, mock_visualizer)
+    mock_analyzer.get_disk_space.assert_called_once_with(os_filter=mock_config.os_name)
+    mock_clioutput.print_formatted_disk_space.assert_called_once_with(
+        mock_analyzer.get_disk_space.return_value, os_filter=mock_config.os_name
+    )
+    mock_visualizer.visualize_disk_space_vertical.assert_called_once_with(
+        mock_analyzer.get_disk_space.return_value, os_filter=mock_config.os_name
+    )
+    mock_visualizer.visualize_disk_space_horizontal.assert_not_called()
+
+
+def test_get_disk_space_ranges_empty(
+    mock_config: MockType, mock_analyzer: MockType, mock_clioutput: MockType, mock_visualizer: MockType
+) -> None:
+    mock_analyzer.get_disk_space.return_value.empty = True
+    __main__.get_disk_space_ranges(mock_config, mock_analyzer, mock_clioutput, mock_visualizer)
+    mock_analyzer.get_disk_space.assert_called_once_with(os_filter=mock_config.os_name)
+    mock_clioutput.print_formatted_disk_space.assert_not_called()
+    mock_visualizer.visualize_disk_space_vertical.assert_not_called()
+    mock_visualizer.visualize_disk_space_horizontal.assert_not_called()
+
+
+def test_get_disk_space_ranges_all_env(
+    mock_config: MockType, mock_analyzer: MockType, mock_clioutput: MockType, mock_visualizer: MockType
+) -> None:
+    mock_analyzer.get_disk_space.return_value.empty = False
+    mock_config.environment_filter = "all"
+    __main__.get_disk_space_ranges(mock_config, mock_analyzer, mock_clioutput, mock_visualizer)
+    mock_analyzer.get_disk_space.assert_called_once_with(os_filter=mock_config.os_name)
+    mock_clioutput.print_formatted_disk_space.assert_called_once_with(
+        mock_analyzer.get_disk_space.return_value, os_filter=mock_config.os_name
+    )
+    mock_visualizer.visualize_disk_space_vertical.assert_not_called
+    mock_visualizer.visualize_disk_space_horizontal.assert_called_once_with(mock_analyzer.get_disk_space.return_value)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -169,6 +169,26 @@ def test_get_unsupported_os_no_graphs(
     mock_visualizer.visualize_unsupported_os_distribution.assert_not_called()
 
 
+def test_get_os_counts(
+    mock_config: MockType, mock_analyzer: MockType, mock_clioutput: MockType, mock_visualizer: MockType
+) -> None:
+    __main__.get_os_counts(mock_config, mock_analyzer, mock_clioutput, mock_visualizer)
+    mock_analyzer.get_operating_system_counts.assert_called_once()
+    mock_clioutput.format_series_output.assert_called_once_with(mock_analyzer.get_operating_system_counts.return_value)
+    mock_visualizer.visualize_os_distribution.assert_called_once_with(
+        mock_analyzer.get_operating_system_counts.return_value, mock_config.minimum_count
+    )
+
+
+def test_get_os_counts_no_graphs(
+    mock_config: MockType, mock_analyzer: MockType, mock_clioutput: MockType, mock_visualizer: MockType
+) -> None:
+    __main__.get_os_counts(mock_config, mock_analyzer, mock_clioutput, None)
+    mock_analyzer.get_operating_system_counts.assert_called_once()
+    mock_clioutput.format_series_output.assert_called_once_with(mock_analyzer.get_operating_system_counts.return_value)
+    mock_visualizer.visualize_os_distribution.assert_not_called()
+
+
 def test_sort_by_site(mock_vmdata: MockType, mock_clioutput: MockType) -> None:
     __main__.sort_by_site(mock_vmdata, mock_clioutput)
     mock_vmdata.create_site_specific_dataframe.assert_called_once()

--- a/tests/unit/test_visualizer.py
+++ b/tests/unit/test_visualizer.py
@@ -103,7 +103,6 @@ def test_visualize_os_distribution(visualizer: Visualizer, all_os_count_series: 
     sorted_series = all_os_count_series[all_os_count_series >= 100].sort_values(ascending=False)
     return visualizer.visualize_os_distribution(
         sorted_series,
-        os_names=list(sorted_series.index),
         min_count=100,
     )
 

--- a/vminfo_parser/__main__.py
+++ b/vminfo_parser/__main__.py
@@ -39,14 +39,6 @@ def output_os_by_version(analyzer: Analyzer, cli_output: CLIOutput, visualizer: 
     analyzer.by_os(output_os_versions)
 
 
-def get_os_counts(config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: Visualizer | None) -> None:
-    counts: pd.Series = analyzer.get_operating_system_counts()
-    cli_output.format_series_output(counts)
-
-    if visualizer:
-        visualizer.visualize_os_distribution(counts, config.minimum_count)
-
-
 def get_disk_space_ranges(
     config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: Visualizer | None
 ) -> None:
@@ -58,6 +50,14 @@ def get_disk_space_ranges(
                 visualizer.visualize_disk_space_horizontal(disk_space_df)
             else:
                 visualizer.visualize_disk_space_vertical(disk_space_df, os_filter=config.os_name)
+
+
+def get_os_counts(config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: Visualizer | None) -> None:
+    counts: pd.Series = analyzer.get_operating_system_counts()
+    cli_output.format_series_output(counts)
+
+    if visualizer:
+        visualizer.visualize_os_distribution(counts, config.minimum_count)
 
 
 def show_disk_space_by_os(

--- a/vminfo_parser/__main__.py
+++ b/vminfo_parser/__main__.py
@@ -111,7 +111,7 @@ def main(*args: str) -> None:  # noqa: C901
             get_os_counts(config, analyzer, cli_output, visualizer)
 
         case config.output_os_by_version:
-            output_os_by_version(config, analyzer, cli_output, visualizer)
+            output_os_by_version(analyzer, cli_output, visualizer)
 
         case config.get_supported_os:
             get_supported_os(config, analyzer, cli_output, visualizer)

--- a/vminfo_parser/__main__.py
+++ b/vminfo_parser/__main__.py
@@ -49,27 +49,14 @@ def output_os_by_version(
                 visualizer.visualize_os_version_distribution(counts_dataframe, os_name)
 
 
-def get_os_counts(config: Config, analyzer: Analyzer) -> None:
-    if config.environments:
-        if config.os_name:
-            analyzer.sort_attribute_by_environment(
-                *config.environments,
-                attribute="operatingSystem",
-                os_filter=config.os_name,
-            )
-        elif config.sort_by_env:
-            analyzer.sort_attribute_by_environment(
-                *config.environments,
-                attribute="operatingSystem",
-                environment_filter=config.sort_by_env,
-            )
-        else:
-            analyzer.sort_attribute_by_environment(*config.environments, attribute="operatingSystem")
-    else:
-        if config.os_name:
-            analyzer.sort_attribute_by_environment(attribute="operatingSystem", os_filter=config.os_name)
-        else:
-            analyzer.sort_attribute_by_environment(attribute="operatingSystem")
+def get_os_counts(
+    config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: t.Optional[Visualizer]
+) -> None:
+    counts: pd.Series = analyzer.get_operating_system_counts()
+    cli_output.format_series_output(counts)
+
+    if visualizer:
+        visualizer.visualize_os_distribution(counts, config.minimum_count)
 
 
 def get_disk_space_ranges(config: Config, analyzer: Analyzer) -> None:
@@ -167,7 +154,7 @@ def main(*args: str) -> None:  # noqa: C901
             get_disk_space_ranges(config, analyzer)
 
         case config.get_os_counts:
-            get_os_counts(config, analyzer)
+            get_os_counts(config, analyzer, cli_output, visualizer)
 
         case config.output_os_by_version:
             output_os_by_version(config, analyzer, cli_output, visualizer)

--- a/vminfo_parser/__main__.py
+++ b/vminfo_parser/__main__.py
@@ -30,10 +30,13 @@ def get_supported_os(config: Config, analyzer: Analyzer, cli_output: CLIOutput, 
 
 
 def output_os_by_version(analyzer: Analyzer, cli_output: CLIOutput, visualizer: Visualizer | None) -> None:
-    for os_name, counts_dataframe in analyzer.generate_os_version_distribution():
+    def output_os_versions(os_name: str) -> None:
+        counts_dataframe = analyzer.get_os_version_distribution(os_name)
         cli_output.format_dataframe_output(counts_dataframe, os_name=os_name)
         if visualizer is not None:
-            visualizer.visualize_os_version_distribution(counts_dataframe, os_name)
+            visualizer.visualize_os_version_distribution(counts_dataframe, os_name=os_name)
+
+    analyzer.by_os(output_os_versions)
 
 
 def get_os_counts(config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: Visualizer | None) -> None:
@@ -60,13 +63,8 @@ def get_disk_space_ranges(
 def show_disk_space_by_os(
     config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: Visualizer | None
 ) -> None:
-    os_names: list[str]
-    if config.os_name:
-        os_names = [config.os_name]
-    else:
-        os_names = analyzer.get_unique_os_names()
 
-    for os_name in os_names:
+    def show_disk_space(os_name: str) -> None:
         disk_space_df = analyzer.get_disk_space(os_filter=os_name)
         if not disk_space_df.empty:
             cli_output.print_formatted_disk_space(disk_space_df, os_filter=os_name)
@@ -75,6 +73,8 @@ def show_disk_space_by_os(
                     visualizer.visualize_disk_space_horizontal(disk_space_df)
                 else:
                     visualizer.visualize_disk_space_vertical(disk_space_df, os_filter=os_name)
+
+    analyzer.by_os(show_disk_space)
 
 
 def sort_by_site(vm_data: VMData, cli_output: CLIOutput) -> None:

--- a/vminfo_parser/__main__.py
+++ b/vminfo_parser/__main__.py
@@ -15,6 +15,14 @@ LOGGER = logging.getLogger(__name__)
 
 
 def get_unsupported_os(analyzer: Analyzer, cli_output: CLIOutput, visualizer: Visualizer | None) -> None:
+    """Get unsupported os counts from analyzer and pass the repsonse to outputs.
+
+    Args:
+        analyzer (Analyzer): Analyzer instance
+        cli_output (CLIOutput): CLI Output instance
+        visualizer (Visualizer | None): Visualizer instance, or None if no graph output desired
+    """
+
     unsupported_counts = analyzer.generate_unsupported_os_counts()
     cli_output.format_series_output(unsupported_counts)
     if visualizer is not None:
@@ -22,6 +30,15 @@ def get_unsupported_os(analyzer: Analyzer, cli_output: CLIOutput, visualizer: Vi
 
 
 def get_supported_os(config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: Visualizer | None) -> None:
+    """Get supported os counts from analyzer and pass the response to outputs
+
+    Args:
+        config (Config): Config instance
+        analyzer (Analyzer): Analyzer instance
+        cli_output (CLIOutput): CLI Output instance
+        visualizer (Visualizer | None): Visualizer instance, or None if no graph output desired
+    """
+
     supported_counts: pd.Series = analyzer.get_supported_os_counts()
 
     cli_output.format_series_output(supported_counts)
@@ -30,7 +47,21 @@ def get_supported_os(config: Config, analyzer: Analyzer, cli_output: CLIOutput, 
 
 
 def output_os_by_version(analyzer: Analyzer, cli_output: CLIOutput, visualizer: Visualizer | None) -> None:
+    """Get os versions from analyzer and pass the result to outputs, once for each os.
+
+    Args:
+        analyzer (Analyzer): Analyzer instance
+        cli_output (CLIOutput): CLI Output instance
+        visualizer (Visualizer | None): Visualizer instance, or None if no graph output desired
+    """
+
     def output_os_versions(os_name: str) -> None:
+        """Get os versions from analyzer and pass the result to outputs.
+
+        Args:
+            os_name (str): OS name for this iteration
+        """
+
         counts_dataframe = analyzer.get_os_version_distribution(os_name)
         cli_output.format_dataframe_output(counts_dataframe, os_name=os_name)
         if visualizer is not None:
@@ -42,6 +73,15 @@ def output_os_by_version(analyzer: Analyzer, cli_output: CLIOutput, visualizer: 
 def get_disk_space_ranges(
     config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: Visualizer | None
 ) -> None:
+    """Get disk space ranges from analyzer and pass to outputs.
+
+    Args:
+        config (Config): Config instance
+        analyzer (Analyzer): Analyzer instance
+        cli_output (CLIOutput): CLI Output instance
+        visualizer (Visualizer | None): Visualizer instance, or None if no graph output desired
+    """
+
     disk_space_df = analyzer.get_disk_space(os_filter=config.os_name)
     if not disk_space_df.empty:
         cli_output.print_formatted_disk_space(disk_space_df, os_filter=config.os_name)
@@ -53,6 +93,15 @@ def get_disk_space_ranges(
 
 
 def get_os_counts(config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: Visualizer | None) -> None:
+    """Get OS counts from analyzer and pass to outputs.
+
+    Args:
+        config (Config): Config instance
+        analyzer (Analyzer): Analyzer instance
+        cli_output (CLIOutput): CLI Output instance
+        visualizer (Visualizer | None): Visualizer instance, or None if no graph output desired
+    """
+
     counts: pd.Series = analyzer.get_operating_system_counts()
     cli_output.format_series_output(counts)
 
@@ -63,8 +112,22 @@ def get_os_counts(config: Config, analyzer: Analyzer, cli_output: CLIOutput, vis
 def show_disk_space_by_os(
     config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: Visualizer | None
 ) -> None:
+    """Get disk space ranges from analyzer and pass to outputs, once for each os.
+
+    Args:
+        config (Config): Config instance
+        analyzer (Analyzer): Analyzer instance
+        cli_output (CLIOutput): CLI Output instance
+        visualizer (Visualizer | None): Visualizer instance, or None if no graph output desired
+    """
 
     def show_disk_space(os_name: str) -> None:
+        """Get disk space ranges from analyzer and pass to outputs.
+
+        Args:
+            os_name (str):  OS name for this iteration
+        """
+
         disk_space_df = analyzer.get_disk_space(os_filter=os_name)
         if not disk_space_df.empty:
             cli_output.print_formatted_disk_space(disk_space_df, os_filter=os_name)
@@ -78,6 +141,12 @@ def show_disk_space_by_os(
 
 
 def sort_by_site(vm_data: VMData, cli_output: CLIOutput) -> None:
+    """Get resource usage by site and output using cli only.
+
+    Args:
+        vm_data (VMData): VMData instance
+        cli_output (CLIOutput): CLI Output instance
+    """
     site_dataframe = vm_data.create_site_specific_dataframe()
     cli_output.print_site_usage(["Memory", "CPU", "Disk", "VM"], site_dataframe)
 

--- a/vminfo_parser/__main__.py
+++ b/vminfo_parser/__main__.py
@@ -21,9 +21,7 @@ def get_unsupported_os(analyzer: Analyzer, cli_output: CLIOutput, visualizer: Vi
         visualizer.visualize_unsupported_os_distribution(unsupported_counts)
 
 
-def get_supported_os(
-    config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: t.Optional[Visualizer]
-) -> None:
+def get_supported_os(config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: Visualizer | None) -> None:
     supported_counts: pd.Series = analyzer.get_supported_os_counts()
 
     cli_output.format_series_output(supported_counts)
@@ -31,22 +29,14 @@ def get_supported_os(
         visualizer.visualize_supported_os_distribution(supported_counts, environment_filter=config.environment_filter)
 
 
-def output_os_by_version(
-    config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: Visualizer | None
-) -> None:
-    for os_name in analyzer.vm_data.df["OS Name"].unique():
-        if os_name is not None and not pd.isna(os_name) and os_name != "":
-            counts_dataframe = analyzer.generate_os_version_distribution(
-                analyzer.vm_data.df, os_name, config.minimum_count
-            )
-            cli_output.format_dataframe_output(counts_dataframe, os_name=os_name)
-            if visualizer is not None:
-                visualizer.visualize_os_version_distribution(counts_dataframe, os_name)
+def output_os_by_version(analyzer: Analyzer, cli_output: CLIOutput, visualizer: Visualizer | None) -> None:
+    for os_name, counts_dataframe in analyzer.generate_os_version_distribution():
+        cli_output.format_dataframe_output(counts_dataframe, os_name=os_name)
+        if visualizer is not None:
+            visualizer.visualize_os_version_distribution(counts_dataframe, os_name)
 
 
-def get_os_counts(
-    config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: t.Optional[Visualizer]
-) -> None:
+def get_os_counts(config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: Visualizer | None) -> None:
     counts: pd.Series = analyzer.get_operating_system_counts()
     cli_output.format_series_output(counts)
 
@@ -55,7 +45,7 @@ def get_os_counts(
 
 
 def get_disk_space_ranges(
-    config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: t.Optional[Visualizer]
+    config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: Visualizer | None
 ) -> None:
     disk_space_df = analyzer.get_disk_space(os_filter=config.os_name)
     if not disk_space_df.empty:
@@ -68,7 +58,7 @@ def get_disk_space_ranges(
 
 
 def show_disk_space_by_os(
-    config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: t.Optional[Visualizer]
+    config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: Visualizer | None
 ) -> None:
     os_names: list[str]
     if config.os_name:

--- a/vminfo_parser/__main__.py
+++ b/vminfo_parser/__main__.py
@@ -21,19 +21,14 @@ def get_unsupported_os(analyzer: Analyzer, cli_output: CLIOutput, visualizer: Vi
         visualizer.visualize_unsupported_os_distribution(unsupported_counts)
 
 
-def get_supported_os(config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: Visualizer | None) -> None:
-    supported_counts: pd.Series
-    if config.prod_env_labels and config.sort_by_env:
-        supported_counts = analyzer.generate_supported_os_counts(
-            *config.prod_env_labels.split(","),
-            environment_filter=config.sort_by_env,
-        )
-    else:
-        supported_counts = analyzer.generate_supported_os_counts(environment_filter=config.sort_by_env)
+def get_supported_os(
+    config: Config, analyzer: Analyzer, cli_output: CLIOutput, visualizer: t.Optional[Visualizer]
+) -> None:
+    supported_counts: pd.Series = analyzer.get_supported_os_counts()
 
     cli_output.format_series_output(supported_counts)
     if visualizer is not None:
-        visualizer.visualize_supported_os_distribution(supported_counts, environment_filter=config.sort_by_env)
+        visualizer.visualize_supported_os_distribution(supported_counts, environment_filter=config.environment_filter)
 
 
 def output_os_by_version(

--- a/vminfo_parser/analyzer.py
+++ b/vminfo_parser/analyzer.py
@@ -426,7 +426,7 @@ class Analyzer:
 
     def generate_os_version_distribution(self: t.Self) -> t.Generator[tuple[str, pd.Series], None, None]:
         for os_name in self.get_unique_os_names():
-            yield os_name, self.get_os_version_distrobution(os_name)
+            yield os_name, self.get_os_version_distribution(os_name)
 
     def get_os_version_distribution(self: t.Self, os_name: str) -> pd.Series:
         df_copy = self.vm_data.df.copy()

--- a/vminfo_parser/analyzer.py
+++ b/vminfo_parser/analyzer.py
@@ -492,18 +492,18 @@ class Analyzer:
 
         return unsupported_counts
 
-    def generate_os_version_distribution(
-        self: t.Self, dataFrame: pd.DataFrame, os_name: str, minimum_count: int
-    ) -> pd.DataFrame:
+    def generate_os_version_distribution(self: t.Self) -> t.Generator[tuple[str, pd.DataFrame], None, None]:
+        for os_name in self.vm_data.df["OS Name"].unique():
+            if os_name is not None and not pd.isna(os_name) and os_name != "":
+                dataFrame = self.vm_data.df.copy()
+                filtered_df = dataFrame[(dataFrame["OS Name"] == os_name)]
+                counts = filtered_df["OS Version"].fillna("unknown").value_counts().reset_index()
+                counts.columns = ["OS Version", "Count"]
 
-        filtered_df = dataFrame[(dataFrame["OS Name"] == os_name)]
-        counts = filtered_df["OS Version"].fillna("unknown").value_counts().reset_index()
-        counts.columns = ["OS Version", "Count"]
+                if self.config.minimum_count is not None and self.config.minimum_count > 0:
+                    counts = counts[counts["Count"] >= self.config.minimum_count]
 
-        if minimum_count is not None and minimum_count > 0:
-            counts = counts[counts["Count"] >= minimum_count]
-
-        return counts
+                yield os_name, counts
 
     def sort_attribute_by_environment(
         self: t.Self,

--- a/vminfo_parser/analyzer.py
+++ b/vminfo_parser/analyzer.py
@@ -1,7 +1,7 @@
 # Std lib imports
 import logging
 import typing as t
-from collections.abc import Callable, Generator
+from collections.abc import Callable
 
 # 3rd party imports
 import pandas as pd

--- a/vminfo_parser/analyzer.py
+++ b/vminfo_parser/analyzer.py
@@ -321,7 +321,7 @@ class Analyzer:
 
         return self.sort_by_disk_space_range(df)
 
-    def get_unique_os_names(self: t.Self, df: pd.DataFrame | None = None) -> list[str]:
+    def get_unique_os_names(self: t.Self) -> list[str]:
         """Generate list of unique os names from dataframe.
 
         Uses vmdata object if no dataframe is passed.

--- a/vminfo_parser/analyzer.py
+++ b/vminfo_parser/analyzer.py
@@ -320,6 +320,10 @@ class Analyzer:
 
         return self.sort_by_disk_space_range(df)
 
+    def generate_disk_space_by_os(self: t.Self) -> t.Generator[tuple[str, pd.DataFrame], None, None]:
+        for os_name in self.get_unique_os_names():
+            yield os_name, self.get_disk_space(os_name)
+
     def get_unique_os_names(self: t.Self) -> list[str]:
         """Returns unique os names from vmdata
 
@@ -420,7 +424,7 @@ class Analyzer:
 
         return unsupported_counts
 
-    def generate_os_version_distribution(self: t.Self) -> t.Generator[tuple[str, pd.DataFrame], None, None]:
+    def generate_os_version_distribution(self: t.Self) -> t.Generator[tuple[str, pd.Series], None, None]:
         for os_name in self.get_unique_os_names():
             yield os_name, self.get_os_version_distrobution(os_name)
 

--- a/vminfo_parser/analyzer.py
+++ b/vminfo_parser/analyzer.py
@@ -239,10 +239,7 @@ class Analyzer:
                 return f"{lower} {lower_unit} - {upper} {upper_unit}"
         return value
 
-    def sort_by_disk_space_range(
-        self: t.Self,
-        dataFrame: pd.DataFrame
-    ) -> pd.DataFrame:
+    def sort_by_disk_space_range(self: t.Self, dataFrame: pd.DataFrame) -> pd.DataFrame:
         """
         Sorts the provided DataFrame by disk space range, optionally breaking down by operating system.
 
@@ -307,10 +304,7 @@ class Analyzer:
 
         return sorted_range_counts_by_environment
 
-    def get_disk_space(
-        self: t.Self,
-        os_filter: str
-    ) -> pd.DataFrame:
+    def get_disk_space(self: t.Self, os_filter: str) -> pd.DataFrame:
         """
         Processes and formats disk space data from the provided DataFrame based on specified filters.
 
@@ -321,7 +315,9 @@ class Analyzer:
         Returns:
             pd.DataFrame: A DataFrame containing counts of disk space ranges, optionally sorted by environment
         """
-        df = self.vm_data.create_environment_filtered_dataframe(self.config.environments, self.config.environment_filter)
+        df = self.vm_data.create_environment_filtered_dataframe(
+            self.config.environments, self.config.environment_filter
+        )
 
         if os_filter:
             df = df[df["OS Name"] == os_filter]

--- a/vminfo_parser/config.py
+++ b/vminfo_parser/config.py
@@ -246,5 +246,5 @@ class Config:
         return []
 
     @cached_property
-    def environment_filter(self: t.Self) -> list[str]:
+    def environment_filter(self: t.Self) -> str:
         return self.sort_by_env if self.sort_by_env else "all"

--- a/vminfo_parser/config.py
+++ b/vminfo_parser/config.py
@@ -244,3 +244,7 @@ class Config:
         if self.prod_env_labels:
             return self.prod_env_labels.split(",")
         return []
+
+    @cached_property
+    def environment_filter(self: t.Self) -> list[str]:
+        return self.sort_by_env if self.sort_by_env else "all"

--- a/vminfo_parser/visualizer.py
+++ b/vminfo_parser/visualizer.py
@@ -136,7 +136,7 @@ class Visualizer:
             min_count (int, optional): minimum count of oses graphed for title. Defaults to 500.
         """
         # this may not be needed anymore, it might be simplifiable to counts.index
-        os_names = [idx[1] for idx in counts.index] if counts.index.nlevels == 2 else counts.index
+        os_names: list[str] = [idx[1] for idx in counts.index] if counts.index.nlevels == 2 else counts.index
         # Plot the counts as a horizontal bar chart with specified and random colors
         counts.plot(kind="barh", rot=45, color=_get_colors(os_names))
 

--- a/vminfo_parser/visualizer.py
+++ b/vminfo_parser/visualizer.py
@@ -127,18 +127,17 @@ class Visualizer:
     def visualize_os_distribution(
         self: t.Self,
         counts: pd.Series,
-        os_names: list[str],
         min_count: int = 500,
     ) -> None:
         """Create horizontal bar chart of OS Counts.
 
         Args:
             counts (pd.Series): series of counts per os
-            os_names (list[str]): names of oses in counts
             min_count (int, optional): minimum count of oses graphed for title. Defaults to 500.
         """
+        # this may not be needed anymore, it might be simplifiable to counts.index
+        os_names = [idx[1] for idx in counts.index] if counts.index.nlevels == 2 else counts.index
         # Plot the counts as a horizontal bar chart with specified and random colors
-        # ax = counts.plot(kind="barh", rot=45, color=colors)
         counts.plot(kind="barh", rot=45, color=_get_colors(os_names))
 
         # Set titles and labels for the plot

--- a/vminfo_parser/vmdata.py
+++ b/vminfo_parser/vmdata.py
@@ -164,5 +164,34 @@ class VMData:
 
         return site_usage
 
+    def create_environment_filtered_dataframe(
+        self: t.Self, prod_envs: list[str], env_filter: t.Optional[str] = None
+    ) -> pd.DataFrame:
+        data_cp = self.df.copy()
+        data_cp[self.column_headers["environment"]] = self.df[self.column_headers["environment"]].apply(
+            _categorize_environment, prod_envs=prod_envs
+        )
+
+        if env_filter and env_filter not in ["all", "both"]:
+            data_cp = data_cp[data_cp[self.column_headers["environment"]] == env_filter]
+
+        return data_cp
+
     def save_to_csv(self: t.Self, path: str) -> None:
         self.df.to_csv(path, index=False)
+
+
+def _categorize_environment(x: str, prod_envs: list[str]) -> str:
+    if pd.isnull(x):
+        return "non-prod"
+
+    if not prod_envs:
+        return "all envs"
+
+    # Ensure x is a string
+    if isinstance(x, str):
+        for env in prod_envs:
+            if env in x:
+                return "prod"
+
+    return "non-prod"

--- a/vminfo_parser/vmdata.py
+++ b/vminfo_parser/vmdata.py
@@ -165,7 +165,7 @@ class VMData:
         return site_usage
 
     def create_environment_filtered_dataframe(
-        self: t.Self, prod_envs: list[str], env_filter: t.Optional[str] = None
+        self: t.Self, prod_envs: list[str], env_filter: str | None = None
     ) -> pd.DataFrame:
         data_cp = self.df.copy()
         data_cp[self.column_headers["environment"]] = self.df[self.column_headers["environment"]].apply(

--- a/vminfo_parser/vmdata.py
+++ b/vminfo_parser/vmdata.py
@@ -167,6 +167,15 @@ class VMData:
     def create_environment_filtered_dataframe(
         self: t.Self, prod_envs: list[str], env_filter: str | None = None
     ) -> pd.DataFrame:
+        """Create copy of dataframe, with environment column replaced with category, and filtered by requested filter
+
+        Args:
+            prod_envs (list[str]): list of environment labels defined as prod. (all other labels will be non-prod)
+            env_filter (str | None, optional): filter to apply to environment column. Defaults to None.
+
+        Returns:
+            pd.DataFrame: dataframe filtered by env_filter with modified environment column
+        """
         data_cp = self.df.copy()
         data_cp[self.column_headers["environment"]] = self.df[self.column_headers["environment"]].apply(
             _categorize_environment, prod_envs=prod_envs
@@ -182,6 +191,15 @@ class VMData:
 
 
 def _categorize_environment(x: str, prod_envs: list[str]) -> str:
+    """Categorize environment value based on configured prod environment labels
+
+    Args:
+        x (str): environment value to compare, passed by pandas when using per row operations
+        prod_envs (list[str]): list of environment labels to define as prod
+
+    Returns:
+        str: environment category, one of ["non-prod", "prod", "all envs"]
+    """
     if pd.isnull(x):
         return "non-prod"
 


### PR DESCRIPTION
This is rebased from the original PR,  with several major changes pulled out,  and already merged to dev.

The three changes in this PR are intricately linked, and splitting them would be a lot of effort.

Environment filtering has been moved to vmdata.

Iterating over unique OSes has been separated to an analyzer method, which also checks and handles os_name filters.
This function takes a callable to execute for each function.

diskspace and os counting are refactored to use the above changes