### PR TITLE
fix: use over-under-tb without additional options

### DIFF
--- a/vminfo_parser/__main__.py
+++ b/vminfo_parser/__main__.py
@@ -186,6 +186,9 @@ def main(*args: str) -> None:  # noqa: C901
         case config.get_unsupported_os:
             get_unsupported_os(analyzer, cli_output, visualizer)
 
+        case config.over_under_tb:
+            get_disk_space_ranges(config, analyzer, cli_output, visualizer)
+
     # Save results if necessary
     vm_data.save_to_csv("output.csv")
 


### PR DESCRIPTION
fix: This pr allows users to specify --over-under-tb without additional options