### PR TITLE
fix: change clioutput.format_series_output to use tabulate

### DIFF
--- a/tests/const.py
+++ b/tests/const.py
@@ -296,7 +296,8 @@ EXPECTED_CLI_OUTPUT = {
         "100 - 114.3 TiB       2"
     ),
     "os_min_counts": (
-        "OS Name\n"
+        "OS Name                     count\n"
+        "------------------------  -------\n"
         "Ubuntu Linux                16583\n"
         "Microsoft Windows Server    13732\n"
         "Oracle Linux                10589\n"
@@ -307,40 +308,43 @@ EXPECTED_CLI_OUTPUT = {
         "Other                         676"
     ),
     "supported_os_all_envs": (
-        "OS Name\n"
+        "OS Name                     count\n"
+        "------------------------  -------\n"
         "Microsoft Windows Server    13732\n"
         "Microsoft Windows            7280\n"
         "SUSE Linux Enterprise        1991\n"
         "Red Hat Enterprise Linux     1150"
     ),
     "supported_os_both_envs": (
-        "Environment               non-prod   prod\n"
-        "OS Name\n"
-        "Microsoft Windows Server      3614  10118\n"
-        "Microsoft Windows              399   6881\n"
-        "SUSE Linux Enterprise          644   1347\n"
-        "Red Hat Enterprise Linux       437    713"
+        "OS Name                     non-prod    prod\n"
+        "------------------------  ----------  ------\n"
+        "Microsoft Windows Server        3614   10118\n"
+        "Microsoft Windows                399    6881\n"
+        "SUSE Linux Enterprise            644    1347\n"
+        "Red Hat Enterprise Linux         437     713"
     ),
     "supported_os_min_count": (
-        "OS Name\n"
+        "OS Name                     count\n"
+        "------------------------  -------\n"
         "Microsoft Windows Server    13732\n"
         "Microsoft Windows            7280\n"
         "SUSE Linux Enterprise        1991\n"
         "Red Hat Enterprise Linux     1150"
     ),
     "supported_os_non_prod": (
-        "OS Name\n"
-        "Microsoft Windows Server    3614\n"
-        "SUSE Linux Enterprise        644\n"
-        "Other                        836"
+        "OS Name                     count\n"
+        "------------------------  -------\n"
+        "Microsoft Windows Server     3614\n"
+        "SUSE Linux Enterprise         644\n"
+        "Other                         836"
     ),
     "unsupported_os_both": (
-        "Environment   non-prod  prod\n"
-        "OS Name\n"
-        "Ubuntu Linux      7041  9542\n"
-        "Oracle Linux      3692  6897\n"
-        "CentOS             138   454\n"
-        "Other               67   609"
+        "OS Name         non-prod    prod\n"
+        "------------  ----------  ------\n"
+        "Ubuntu Linux        7041    9542\n"
+        "Oracle Linux        3692    6897\n"
+        "CentOS               138     454\n"
+        "Other                 67     609"
     ),
     "disk_space_by_os": (
         "CentOS\n"

--- a/tests/unit/test_clioutput.py
+++ b/tests/unit/test_clioutput.py
@@ -153,23 +153,34 @@ def test_create_site_table(
 
 
 @pytest.mark.parametrize(
-    "series, expected",
+    "dataFrame, headers, table_format, expected",
     [
         (
-            pd.Series(
-                [732, 280, 1100],
-                index=["Microsoft Windows Server", "SUSE Linux Enterprise", "Red Hat Enterprise Linux"],
-                name="Operating Systems",
-            ),
-            "Microsoft Windows Server     732\n"
-            "SUSE Linux Enterprise        280\n"
-            "Red Hat Enterprise Linux    1100\n",
+            pd.DataFrame(
+                {
+                    "Count": [732, 280, 1100],
+                    "Operating Systems": [
+                        "Microsoft Windows Server",
+                        "SUSE Linux Enterprise",
+                        "Red Hat Enterprise Linux",
+                    ],
+                }
+            ).set_index("Operating Systems"),
+            ["OS Name", "Count"],
+            "simple",
+            "OS Name                     Count\n"
+            "------------------------  -------\n"
+            "Microsoft Windows Server      732\n"
+            "SUSE Linux Enterprise         280\n"
+            "Red Hat Enterprise Linux     1100\n",
         )
     ],
     ids=["default"],
 )
-def test_format_series_output(cli_output: CLIOutput, series: pd.Series, expected: str) -> None:
-    cli_output.format_series_output(series)
+def test_format_series_output(
+    cli_output: CLIOutput, dataFrame: pd.DataFrame, headers: list, table_format: str, expected: str
+) -> None:
+    cli_output.format_series_output(dataFrame, headers, table_format)
     result = cli_output.output.getvalue()
     assert result == expected
 

--- a/vminfo_parser/__main__.py
+++ b/vminfo_parser/__main__.py
@@ -186,6 +186,9 @@ def main(*args: str) -> None:  # noqa: C901
         case config.get_unsupported_os:
             get_unsupported_os(analyzer, cli_output, visualizer)
 
+        case config.over_under_tb:
+            get_disk_space_ranges(config, analyzer, cli_output, visualizer)
+
     # Save results if necessary
     vm_data.save_to_csv("output.csv")
 

--- a/vminfo_parser/clioutput.py
+++ b/vminfo_parser/clioutput.py
@@ -82,10 +82,12 @@ class CLIOutput:
                 for version, count_value in zip(os_version, count):
                     self.writeline(f"{version.ljust(32)} {count_value}")
 
-    def format_series_output(self: t.Self, counts: pd.Series) -> None:
-        for line in str(counts).split("\n"):
-            if not line.startswith("Name:") and not line.startswith("dtype"):
-                self.writeline(line.strip())
+    def format_series_output(
+        self: t.Self, counts: pd.Series, headers: list = "keys", table_format: str = "simple"
+    ) -> None:
+        df = pd.DataFrame(counts)
+        table = tabulate(df, headers=headers, tablefmt=table_format)
+        self.writeline(table)
 
     def print_formatted_disk_space(
         self: t.Self,


### PR DESCRIPTION
fix: As part of #91 I noticed that the output for this path was not using tabulate.

This PR  fixes that and updates the associated unit tests and e2e tests