### PR TITLE
fix(vmdata): Make the environment heading optional

### DIFF
--- a/vminfo_parser/const.py
+++ b/vminfo_parser/const.py
@@ -16,6 +16,16 @@ COLUMN_HEADERS = MappingProxyType(
             {
                 "operatingSystemFromVMConfig": "OS according to the configuration file",
                 "operatingSystemFromVMTools": "OS according to the VMware Tools",
+                "environment": "Environment",
+                "vmMemory": "Memory",
+                "vmDisk": "Provisioned MiB",
+                "vCPU": "CPUs",
+            }
+        ),
+        "VERSION_3": MappingProxyType(
+            {
+                "operatingSystemFromVMConfig": "OS according to the configuration file",
+                "operatingSystemFromVMTools": "OS according to the VMware Tools",
                 "environment": "ent-env",
                 "vmMemory": "Memory",
                 "vmDisk": "Total disk capacity MiB",

--- a/vminfo_parser/vmdata.py
+++ b/vminfo_parser/vmdata.py
@@ -109,6 +109,15 @@ class VMData:
         self.unit_type = "GiB" if best_match == "VERSION_1" else "MiB"
 
         missing_headers = [header for header in self.column_headers.values() if header not in self.df.columns]
+        if self.column_headers["environment"] in missing_headers:
+            LOGGER.warning(
+                "Environment heading %s is missing. Inserting empty column so program can continue"
+                % self.column_headers["environment"]
+            )
+            self.df[self.column_headers["environment"]] = ""
+            # We want to remove the environment header from the list so that any remaining headers are still 
+            # caught as missing
+            missing_headers.remove(self.column_headers["environment"])
         if missing_headers:
             LOGGER.critical("The following headers are missing: %s", missing_headers)
             exit()


### PR DESCRIPTION
fix: This PR will make it so that the environment header is no longer required. The application throws a warning if it doesn't exist

```
WARNING:vminfo_parser.vmdata:Environment heading Environment is missing. Inserting empty column so program can continue
```

The program will now create an header with all values being empty.